### PR TITLE
Update DI Schema

### DIFF
--- a/merchant/components/schemas/v1DeleteOrderRequestSegment.yaml
+++ b/merchant/components/schemas/v1DeleteOrderRequestSegment.yaml
@@ -4,4 +4,6 @@ properties:
     type: boolean
   order_id:
     $ref: ./v1UUID.yaml
+  external_order_id:
+    type: string
 title: Delete Section

--- a/merchant/components/schemas/v1DeleteOrderRequestSegment.yaml
+++ b/merchant/components/schemas/v1DeleteOrderRequestSegment.yaml
@@ -6,4 +6,5 @@ properties:
     $ref: ./v1UUID.yaml
   external_order_id:
     type: string
+    description: External Order Id of order/cart to be deleted. This is only passed in the case of cart checkout where we want to delete an external cart that has no Fast ID associated with it.
 title: Delete Section

--- a/order/components/schemas/v1RefundOrderRequest.yaml
+++ b/order/components/schemas/v1RefundOrderRequest.yaml
@@ -2,7 +2,7 @@ type: object
 properties:
   order_id:
     $ref: ./v1UUID.yaml
-  refund_id:
+  external_refund_id:
     type: string
   reason:
     $ref: ./v1RefundReasonCode.yaml

--- a/order/components/schemas/v1RefundOrderRequest.yaml
+++ b/order/components/schemas/v1RefundOrderRequest.yaml
@@ -4,6 +4,7 @@ properties:
     $ref: ./v1UUID.yaml
   external_refund_id:
     type: string
+    description: Id provided by the seller to tie back the refund on their end. Should be unique for each refund.
   reason:
     $ref: ./v1RefundReasonCode.yaml
   note:


### PR DESCRIPTION
The schema for Seller->Fast Refund had an incorrect field name (refund_id but we expect external_refund_id)

Additionally we added support to delete based on platform order id so updated the schema to include external_order_id