### PR TITLE
Immediate fixes needed for incorrect links and formatting issues

### DIFF
--- a/developer-portal/Sign-Up-With-BigCommerce.md
+++ b/developer-portal/Sign-Up-With-BigCommerce.md
@@ -1,81 +1,86 @@
-# Sign Up with BigCommerce
-## Prerequisites
-Before you begin this process, you’ll need an online store hosted by BigCommerce. See [Fast Overview and Prerequisites](https://docs.google.com/document/d/1E4BGaI4w9Iy8Otb18QfFiTrHvjvdn08_4K5RU7vjKgQ/edit#heading=h.623o5uhwmywu) for more information about this and other prerequisites. If you need help at any point, contact customer success at seller-support@fast.co.
-1. On [fast.co/business](https://www.fast.co/business), enter the following information and click “Next:”
-- Your preferred email address (You can add additional email addresses for access later.)
-- Your first name and your last name (If your business has multiple employees, you can add more people later and give those people various levels of access and permissions.)
+---
+keywords: BigCommerce
+---
 
-![Get-Started-As-A-Seller-box](images/signup-images-small/both1.png)
+# Sign Up with BigCommerce
+
+## Prerequisites
+
+Before you begin this process, you’ll need an online store hosted by BigCommerce. See [Fast Overview and Prerequisites](Fast-Overview-and-Prerequisites.md) for more information about this and other prerequisites. If you need help at any point, contact customer success at seller-support@fast.co.
+
+1. On [fast.co/business](https://www.fast.co/business), enter the following information and click “Next:”
+
+   - Your preferred email address (You can add additional email addresses for access later.)
+   - Your first name and your last name (If your business has multiple employees, you can add more people later and give those people various levels of access and permissions.)
+
+     ![Get-Started-As-A-Seller-box](images/signup-images-small/both1.png)
 
 2. Fast will now send a PIN number to your email inbox. Open your email to find this PIN number and enter it here on Fast.
+   **Note**: Fast doesn’t use passwords. We use PIN numbers instead.
 
-**Note**: Fast doesn’t use passwords. We use PIN numbers instead.
+   ![PIN-number-box](images/signup-images-small/both2.png)
 
-![PIN-number-box](images/signup-images-small/both2.png)
+3. On the Org Details page, enter the following information and click “Next”:
 
+   - Your company name
+   - Your company address
+   - Your company phone number
+   - Your referral number if you were referred to Fast through a partner (This is optional.)
 
-3. On the Org Details page, enter the following information and  click “Next”:
-- Your company name
-- Your company address
-- Your company phone number
-- Your referral number if you were referred to Fast through a partner (This is optional.)
+     ![Org-details-page](images/signup-images-small/both3.png)
 
-![Org-details-page](images/signup-images-small/both3.png)
+4. On the Store Details page, enter the following information and click “Next”:
 
-4. On the Store Details page, enter the following information and  click “Next”:
-- Your website domain
-- Your company name
-- The country where your business is registered
-
-![Store-details-page](images/signup-images-small/both4.png)
+   - Your website domain
+   - Your company name
+   - The country where your business is registered
+     ![Store-details-page](images/signup-images-small/both4.png)
 
 5. On the Platform Page, click “BigCommerce.” Then click “Next.”
-![Platform-page](images/signup-images-small/big1.png)
+
+   ![Platform-page](images/signup-images-small/big1.png)
 
 6. On the page that says “Connect to BigCommerce,” click “Connect.”
 
 7. Click “Log in” and log into your BigCommerce account.
+   **Note**: You need BigCommerce Store Owner access to do this.
+   **Note**: When you reach this specific step, you’ll need to complete the step immediately, without clicking the back button. Otherwise, you’ll have to restart this process from the beginning. This rule does not apply to other steps.
 
-**Note**: You need BigCommerce Store Owner access to do this.
-
-**Note**: When you reach this specific step, you’ll need to complete the step immediately, without clicking the back button. Otherwise, you’ll have to restart this process from the beginning. This rule does not apply to other steps.
-
-![Bigcommerce-Login](images/signup-images-small/big22.png)
+   ![Bigcommerce-Login](images/signup-images-small/big22.png)
 
 8. Click the checkbox and click “Confirm.”
-
-![Confirm](images/signup-images-small/big3.png)
+   ![Confirm](images/signup-images-small/big3.png)
 
 9. If you want to, you can click “Help Me go Fast.” You don’t have to do this step. If you do this step, then also click the X in the pop-up that appears and continue to step 10. If you choose not to do this step, simply go straight to step 10.
-![Install](images/signup-images-small/big4.png)
 
-![Request-Received](images/signup-images/both5.png)
+   ![Install](images/signup-images-small/big4.png)
+
+   ![Request-Received](images/signup-images/both5.png)
 
 10. Click “Next.”
 11. Click “Continue account setup.”
 
-![Business-verification](images/signup-images-small/both6.png)
-
+    ![Business-verification](images/signup-images-small/both6.png)
 
 12. Enter your tax ID, such as your EIN or the equivalent depending on your region. Then click “Continue.”
-![Business-details](images/signup-images-small/both7.png)
 
+    ![Business-details](images/signup-images-small/both7.png)
 
-13. Wait several seconds while Stripe verifies your business. If this verification is unsuccessful, contact customer success at seller-support@fast.co. Otherwise, move onto step 14.
+13) Wait several seconds while Stripe verifies your business. If this verification is unsuccessful, contact customer success at seller-support@fast.co. Otherwise, move onto step 14.
+    **Note**: If you operate under a DBA, you will need to click the pencil icon in order to enter your legal name that correlates with your tax ID.
 
-**Note**: If you operate under a DBA, you will need to click the pencil icon in order to enter your legal name that correlates with your tax ID.
-
-![Stripe](images/signup-images-small/both8.png)
+    ![Stripe](images/signup-images-small/both8.png)
 
 14. On the Bank Details page, enter the following information and click “Finalize Application:”
-- The legal entity the bank account was registered under
-- The currency you use, such as dollars or Euros
-- The country your bank account is in
-- The applicable bank account details depending on your region
 
-**Note**: Which settlement currency you can use depends on which country your business is registered in. And which bank account details you see depends on what settlement currency you use. See [this article](https://stripe.com/docs/connect/bank-debit-card-payouts#supported-settlement) for more information.
+    - The legal entity the bank account was registered under
+    - The currency you use, such as dollars or Euros
+    - The country your bank account is in
+    - The applicable bank account details depending on your region
+      **Note**: Which settlement currency you can use depends on which country your business is registered in. And which bank account details you see depends on what settlement currency you use. See [this article](https://stripe.com/docs/connect/bank-debit-card-payouts#supported-settlement) for more information.
 
-![Bank-details](images/signup-images-small/both9.png)
+      ![Bank-details](images/signup-images-small/both9.png)
 
 15. Click “Continue to Dashboard.”
-![Finish](images/signup-images-small/both10.png)
+
+    ![Finish](images/signup-images-small/both10.png)

--- a/developer-portal/Sign-Up-With-WooCommerce.md
+++ b/developer-portal/Sign-Up-With-WooCommerce.md
@@ -1,77 +1,85 @@
 # Sign Up with WooCommerce
+
 ## Prerequisites
-Before you begin this process, you’ll need an online store hosted by WooCommerce. See [Fast Overview and Prerequisites](https://docs.google.com/document/d/1E4BGaI4w9Iy8Otb18QfFiTrHvjvdn08_4K5RU7vjKgQ/edit#heading=h.623o5uhwmywu) for more information about this and other prerequisites. If you need help at any point, contact customer success at seller-support@fast.co.
+
+Before you begin this process, you’ll need an online store hosted by WooCommerce. See [Fast Overview and Prerequisites](Fast-Overview-and-Prerequisites.md) for more information about this and other prerequisites. If you need help at any point, contact customer success at seller-support@fast.co.
+
 1. On [fast.co/business](https://www.fast.co/business), enter the following information and click “Next:”
-- Your preferred email address (You can add additional email addresses for access later.)
-- Your first name and your last name (If your business has multiple employees, you can add more people later and give those people various levels of access and permissions.)
 
-![Get-Started-As-A-Seller-box](images/signup-images-small/both1.png)
+   - Your preferred email address (You can add additional email addresses for access later.)
+   - Your first name and your last name (If your business has multiple employees, you can add more people later and give those people various levels of access and permissions.)
 
+     ![Get-Started-As-A-Seller-box](images/signup-images-small/both1.png)
 
 2. Fast will now send a PIN number to your email inbox. Open your email to find this PIN number and enter it here on Fast.
+   **Note**: Fast doesn’t use passwords. We use PIN numbers instead.
 
-**Note**:  Fast doesn’t use passwords. We use PIN numbers instead.
-
-![PIN-number-box](images/signup-images-small/both2.png)
-
+   ![PIN-number-box](images/signup-images-small/both2.png)
 
 3. On the Org Details page, enter the following information and then click “Next”:
-- Your company name
-- Your company address
-- Your company phone number
-- Your referral number if you were referred to Fast through a partner (This is optional.)
-![Org-details-page](images/signup-images-small/both3.png)
+
+   - Your company name
+   - Your company address
+   - Your company phone number
+   - Your referral number if you were referred to Fast through a partner (this is optional)
+
+     ![Org-details-page](images/signup-images-small/both3.png)
 
 4. On the Store Details page, enter the following information and then click “Next”:
-- Your website domain
-- Your company name
-- The country where your business is registered
-![Store-details-page](images/signup-images-small/both4.png)
+
+   - Your website domain
+   - Your company name
+   - The country where your business is registered
+
+     ![Store-details-page](images/signup-images-small/both4.png)
 
 5. On the Platform Page, click “WooCommerce.” Then click “Next.”
-![Platform-page](images/signup-images-small/woo1.png)
+
+   ![Platform-page](images/signup-images-small/woo1.png)
 
 6. On the page that says “Connect to WooCommerce,” click “Connect.”
-![Connect](images/signup-images-small/woo2.png)
+
+   ![Connect](images/signup-images-small/woo2.png)
 
 7. Enter your username and password from your WooCommerce store account.
-**Note**: You need WooCommerce Store Admin access or higher to do this.
-**Note**: When you reach this specific step, you’ll need to complete the step immediately without clicking the back button. Otherwise, you will have to restart this process from the beginning. This rule does not apply to other steps.
-![Login](images/signup-images-small/woo33.png)
+   **Note**: You need WooCommerce Store Admin access or higher to do this.
+   **Note**: When you reach this specific step, you’ll need to complete the step immediately without clicking the back button. Otherwise, you will have to restart this process from the beginning. This rule does not apply to other steps.
+
+   ![Login](images/signup-images-small/woo33.png)
 
 8. Click “Approve.”
-
-![Approve](images/signup-images-small/woo44.png)
+   ![Approve](images/signup-images-small/woo44.png)
 
 9. If you want to, you can click “Request professional installation.” You don’t have to do this step. If you do this step, then also click the X in the pop-up that appears and continue to step 10. If you choose not to do this step, simply go straight to step 10.
 
-![Install](images/signup-images-small/woo5.png)
+   ![Install](images/signup-images-small/woo5.png)
 
-![Request-Received](images/signup-images-small/both5.png)
+   ![Request-Received](images/signup-images-small/both5.png)
 
 10. Click “Next.”
 11. Click “Continue account setup.”
 
-![Business-verification](images/signup-images-small/both6.png)
-
+    ![Business-verification](images/signup-images-small/both6.png)
 
 12. Enter your tax ID, such as your EIN or the equivalent depending on your region. Then click “Continue.”
-![Business-details](images/signup-images-small/both7.png)
 
+    ![Business-details](images/signup-images-small/both7.png)
 
 13. Wait several seconds while Stripe verifies your business. If this verification is unsuccessful, contact customer success at seller-support@fast.co. Otherwise, move onto step 14.
-**Note**: If you operate under a DBA, you will need to click the pencil icon in order to enter your legal name that correlates with your tax ID..
-![Stripe](images/signup-images-small/both8.png)
+    **Note**: If you operate under a DBA, you will need to click the pencil icon in order to enter your legal name that correlates with your tax ID..
 
-14. On the Bank Details page, enter the following information and  click “Finalize Application:”
-- The legal entity the bank account was registered under
-- The currency you use, such as dollars or Euros
-- The country your bank account is in
-- The applicable bank account details depending on your region
+    ![Stripe](images/signup-images-small/both8.png)
 
-**Note**: Which settlement currency you can use depends on which country your business is registered in. And which bank account details you see depends on what settlement currency you use. See [this article](https://stripe.com/docs/connect/bank-debit-card-payouts#supported-settlement) for more information.
+14. On the Bank Details page, enter the following information and click “Finalize Application:”
 
-![Bank-details](images/signup-images-small/both9.png)
+    - The legal entity the bank account was registered under
+    - The currency you use, such as dollars or Euros
+    - The country your bank account is in
+    - The applicable bank account details depending on your region
+      **Note**: Which settlement currency you can use depends on which country your business is registered in. And which bank account details you see depends on what settlement currency you use. See [this article](https://stripe.com/docs/connect/bank-debit-card-payouts#supported-settlement) for more information.
+
+      ![Bank-details](images/signup-images-small/both9.png)
 
 15. Click “Continue to Dashboard.”
-![Finish](images/signup-images-small/both10.png)
+
+    ![Finish](images/signup-images-small/both10.png)


### PR DESCRIPTION
Live site should not have links to internal doc, both on WooCommerce and BigCommerce signup pages, as well as indentation and other formatting issues (e.g. with ordered and unordered lists, images, etc.).

Preview docs changes:

- existing BigCommerce page: https://www.fast.co/docs/developer-portal/sign-up-with-bigcommerce/
- possible fixes: https://preview.redoc.ly/fastaf/immediately-necessary-corrections/developer-portal/sign-up-with-bigcommerce/



- existing WooCommerce page: https://www.fast.co/docs/developer-portal/sign-up-with-bigcommerce/
- possible fixes: https://preview.redoc.ly/fastaf/immediately-necessary-corrections/developer-portal/sign-up-with-woocommerce/
